### PR TITLE
Name fields on Participant and LobbyInfo packets now converts to UTF-8

### DIFF
--- a/src/Packets/LobbyInfoPacket.cs
+++ b/src/Packets/LobbyInfoPacket.cs
@@ -28,14 +28,14 @@ namespace Codemasters.F1_2021
             LobbyPlayers = ToAdd.ToArray();
 
         }
-        
+
         public class LobbyInfoData
         {
             public bool AiControlled { get; set; }
             public Team TeamId { get; set; }
             public byte Nationality { get; set; }
             public string Name { get; set; }
-            public byte CarNumber {get; set;}
+            public byte CarNumber { get; set; }
             public ReadyStatus ReadyStatus { get; set; }
 
             public static LobbyInfoData Create(byte[] bytes)
@@ -54,11 +54,7 @@ namespace Codemasters.F1_2021
                 ToReturn.Nationality = BAM.NextByte();
 
                 //name
-                for (var t = 1; t <= 48; t++)
-                {
-                    var currentChar = Convert.ToChar(BAM.NextByte());
-                    ToReturn.Name += currentChar.ToString();
-                }
+                ToReturn.Name = System.Text.Encoding.UTF8.GetString(BAM.NextBytes(48)).Trim();
 
                 //Car number
                 ToReturn.CarNumber = BAM.NextByte();
@@ -76,7 +72,7 @@ namespace Codemasters.F1_2021
             Ready = 1,
             Spectating = 2
         }
-     
+
     }
 
 }

--- a/src/Packets/ParticipantPacket.cs
+++ b/src/Packets/ParticipantPacket.cs
@@ -30,9 +30,9 @@ namespace Codemasters.F1_2021
         {
             public bool IsAiControlled { get; set; }
             public Driver PilotingDriver { get; set; }
-            public byte NetworkId {get; set;} //New to F1 2021
+            public byte NetworkId { get; set; } //New to F1 2021
             public Team ManufacturingTeam { get; set; }
-            public bool MyTeam {get; set;} //New to F1 2021. Indicates if it is their own team
+            public bool MyTeam { get; set; } //New to F1 2021. Indicates if it is their own team
             public byte CarRaceNumber { get; set; }
             public byte NationalityId { get; set; } //I'm too lazy to do this right now.  Will leave it as a byte ID for now... -Tim 1/26/2020
             public string Name { get; set; }
@@ -67,13 +67,7 @@ namespace Codemasters.F1_2021
                 ReturnInstance.NationalityId = BAM.NextByte();
 
                 //Get name
-                string FullName = "";
-                int t = 1;
-                for (t = 1; t <= 48; t++)
-                {
-                    char ThisChar = Convert.ToChar(BAM.NextByte());
-                    FullName = FullName + ThisChar.ToString();
-                }
+                string FullName = System.Text.Encoding.UTF8.GetString(BAM.NextBytes(48));
                 ReturnInstance.Name = FullName.Trim();
 
                 //Get telemetry private or not.


### PR DESCRIPTION
In [actual UDP specification](https://forums.codemasters.com/topic/80231-f1-2021-udp-specification/) there's mention about encoding of "name" field.
It's should be encoded to UTF-8 format, but it's not in project.

Might also be actual for F1 2020 telemetry.